### PR TITLE
more power for your postfix+dovecot container

### DIFF
--- a/dovecot/dovecot-sql.conf
+++ b/dovecot/dovecot-sql.conf
@@ -1,4 +1,4 @@
 driver = mysql
 connect = host={{DB_HOST}} dbname={{DB_NAME}} user={{DB_USER}} password={{DB_PASSWORD}}
-default_pass_scheme = PLAIN-MD5
+default_pass_scheme = PLAIN
 password_query = SELECT email as user, password FROM mail_view_users WHERE email='%u';

--- a/dovecot/local.conf
+++ b/dovecot/local.conf
@@ -1,7 +1,7 @@
 protocols = imap pop3
 disable_plaintext_auth = no
 
-mail_location = maildir:/home/vmail/%d
+mail_location = maildir:/home/vmail/%d/%n/Maildir
 
 auth_default_realm = {{APP_HOST}}
 auth_verbose = yes

--- a/start.sh
+++ b/start.sh
@@ -46,7 +46,10 @@ sed -i "s/{{DB_NAME}}/$DB_NAME/g" /etc/dovecot/dovecot-sql.conf
 sed -i "s/{{DB_PASSWORD}}/$DB_PASSWORD/g" /etc/dovecot/dovecot-sql.conf
 
 sed -i "s/{{APP_HOST}}/$APP_HOST/g" /etc/dovecot/local.conf
+postconf -e myhostname="$APP_HOST"
 
+[ -z ${MYNETWORKS+x} ] || postconf -e "`postconf mynetworks` $MYNETWORKS"
+[ -z ${RELAYHOST+x} ] || postconf -e "relayhost = $RELAYHOST"
 mkdir /run/dovecot
 chmod -R +r /run/dovecot
 chmod -R +w /run/dovecot
@@ -56,4 +59,6 @@ rsyslogd
 
 # run Postfix and Dovecot
 postfix start
-dovecot -F
+dovecot
+tail -f /var/log/mail.log
+


### PR DESCRIPTION
 * enabled and configured sasl authentication w/ dovecot
 * enabled and configured postfix submission service (bypassing port 25, which is often blocked by ISPs)
 * enabled multiple domains to be served
 * additional ENV variables, MYNETWORKS and RELAYHOST. Second may be needed if your ISP blocks outgoing mail delivery except to theirs MTA.
 * dovecot started as daemon, docker logs on container should work sensibly now.